### PR TITLE
Fix font-lock error when invoke git-gutter+-stage-and-commit

### DIFF
--- a/git-gutter+.el
+++ b/git-gutter+.el
@@ -531,6 +531,7 @@ calculated width looks wrong. (This can happen with some special characters.)"
         (insert "\n")
         (goto-char (point-min))
         (diff-mode)
+        (view-mode)
         (pop-to-buffer (current-buffer))))))
 
 (defun git-gutter+-next-hunk (arg)
@@ -809,7 +810,8 @@ If TYPE is not `modified', also remove all deletion (-) lines."
     (let ((default-directory dir))
       (git-gutter+-call-git '("diff" "--staged") file))
     (goto-char (point-min))
-    (diff-mode)))
+    (diff-mode)
+    (view-mode)))
 
 (defsubst git-gutter+-abort-commit-when-no-changes (allow-empty amend)
   (unless (or amend


### PR DESCRIPTION
To avoid error like `(void-function git-commit-mode-font-lock-keywords)`.

Also, I think enable view-mode in diff buffer is a good idea. Maybe I should move this commit to another PR?
