### PR TITLE
git-gutter+-refresh: resolve symlinks

### DIFF
--- a/git-gutter+.el
+++ b/git-gutter+.el
@@ -582,6 +582,7 @@ calculated width looks wrong. (This can happen with some special characters.)"
   (git-gutter+-clear)
   (let ((file (buffer-file-name)))
     (when (and file (file-exists-p file))
+      (setq file (file-truename file))
       (if (file-remote-p file)
           (let* ((repo-root (git-gutter+-root-directory file))
                  (default-directory (git-gutter+-remote-default-directory repo-root file)))


### PR DESCRIPTION
Apply `file-truename` to the `buffer-file-name` so that
`git-gutter+-process-diff` receives a relative path, even when the
file initially open was a symbolic link over Tramp.
