### PR TITLE
support refresh with newer versions of magit

### DIFF
--- a/git-gutter+.el
+++ b/git-gutter+.el
@@ -1169,7 +1169,10 @@ set remove it."
 (defvar git-gutter+-staged-files nil)
 
 (eval-after-load 'magit
-  '(add-hook 'magit-refresh-status-hook 'git-gutter+-on-magit-refresh-status))
+  ;; Older versions of magit
+  '(add-hook 'magit-refresh-status-hook 'git-gutter+-on-magit-refresh-status)
+  ;; Newer versions of magit
+  '(add-hook 'magit-refresh-buffer-hook 'git-gutter+-on-magit-refresh-status))
 
 (defun git-gutter+-on-magit-refresh-status ()
   (let ((head (git-gutter+-get-magit-head)))
@@ -1191,9 +1194,9 @@ set remove it."
 (defun git-gutter+-get-magit-staged-files ()
   (save-excursion
     (goto-char (point-min))
-    (when (re-search-forward "^Staged changes:$" nil t)
+    (when (re-search-forward "^Staged changes" nil t)
       (let (staged-files)
-        (while (re-search-forward "^\\s-*Modified\\s-+\\(.+\\)$" nil t)
+        (while (re-search-forward "^\\s-*[Mm]odified\\s-+\\(.+\\)$" nil t)
           (push (match-string-no-properties 1) staged-files))
         staged-files))))
 

--- a/git-gutter+.el
+++ b/git-gutter+.el
@@ -1173,7 +1173,7 @@ set remove it."
   '(add-hook 'magit-refresh-status-hook 'git-gutter+-on-magit-refresh-status))
 ;; Newer versions of magit
 (eval-after-load 'magit
-  '(add-hook 'magit-refresh-buffer-hook 'git-gutter+-on-magit-refresh-status))
+  '(add-hook 'magit-status-refresh-hook 'git-gutter+-on-magit-refresh-status))
 
 (defun git-gutter+-on-magit-refresh-status ()
   (let ((head (git-gutter+-get-magit-head)))

--- a/git-gutter+.el
+++ b/git-gutter+.el
@@ -1168,10 +1168,11 @@ set remove it."
 (defvar git-gutter+-previously-staged-files nil)
 (defvar git-gutter+-staged-files nil)
 
+;; Older versions of magit
 (eval-after-load 'magit
-  ;; Older versions of magit
-  '(add-hook 'magit-refresh-status-hook 'git-gutter+-on-magit-refresh-status)
-  ;; Newer versions of magit
+  '(add-hook 'magit-refresh-status-hook 'git-gutter+-on-magit-refresh-status))
+;; Newer versions of magit
+(eval-after-load 'magit
   '(add-hook 'magit-refresh-buffer-hook 'git-gutter+-on-magit-refresh-status))
 
 (defun git-gutter+-on-magit-refresh-status ()


### PR DESCRIPTION
In newer versions of `magit`, there are a couple changes from older versions:
- `magit-refresh-status-hook` is gone. Now there is `magit-refresh-buffer-hook`.
- "Staged changes:" has become "Staged changes (#)", giving the number of changes staged, with no colon.
- "Modified" has become "modified" (a change in case).

This pull request makes corresponding changes so that `git-gutter+` refreshes appropriately when using new versions of `magit`, and shouldn't break the same behavior even with older versions of `magit`.

My tweaked version is working for me - let me know if this will work merged in here! Thanks for the great tool!
