### PR TITLE
Update git-commit-mode font lock for upstream changes

### DIFF
--- a/git-gutter+.el
+++ b/git-gutter+.el
@@ -1072,7 +1072,7 @@ set remove it."
   ;; The following is copied from `git-commit-mode'.
   ;; Directly deriving from `git-commit-mode' would pull in unwanted setup code
   ;; that's incompatible with `git-gutter+-commit-mode'.
-  (setq font-lock-defaults (list (git-commit-mode-font-lock-keywords) t))
+  (setq font-lock-defaults (list git-commit-font-lock-keywords t))
   (set (make-local-variable 'font-lock-multiline) t)
   (git-commit-propertize-diff)
   (setq fill-column git-commit-fill-column)


### PR DESCRIPTION
Magit just (19 days ago) refactored their structuring of the font-lock keywords. Instead of `git-commit-mode-font-lock-keywords` being a function, it's now `git-commit-font-lock-keywords` as a `defvar`. The result is that currently `git-gutter+` is broken against HEAD Magit. The patch is pretty trivial.

Relevant commits:
- magit/magit#7a50bfdb0b06009a15098885ebb08241531bda8d
- magit/magit#08a8ac72e4bd3b975114bd6fed43d5e3fe22052d