### PR TITLE
Support newer versions of tramp

### DIFF
--- a/git-gutter+.el
+++ b/git-gutter+.el
@@ -580,13 +580,15 @@ Returns t on zero exit code, nil otherwise."
 
 (defun git-gutter+-remote-default-directory (dir file)
   (let* ((vec (tramp-dissect-file-name file))
-         (method (aref vec 0))
-         (user (aref vec 1))
-         (host (aref vec 2)))
-    (format "/%s:%s%s:%s" method (if user (concat user "@") "") host dir)))
+          (method (tramp-file-name-method vec))
+          (user (tramp-file-name-user vec))
+          (domain (tramp-file-name-domain vec))
+          (host (tramp-file-name-host vec))
+          (port (tramp-file-name-port vec)))
+     (tramp-make-tramp-file-name method user domain host port dir)))
 
 (defun git-gutter+-remote-file-path (dir file)
-  (let ((file (aref (tramp-dissect-file-name file) 3)))
+  (let ((file (tramp-file-name-localname (tramp-dissect-file-name file))))
     (replace-regexp-in-string (concat "\\`" dir) "" file)))
 
 (defun git-gutter+-local-file-path (file)


### PR DESCRIPTION
The data structure of the return value of `tramp-dissect-file-name` was changed from a vector to a cl-structure class, and the implementation in git-gutter-plus assumes it to be a vector. This PR uses the API (I checked the APIs are available even in Emacs 23) provided by tramp.el to fix the problem. This avoids the type check in #39 , and fixes #42 .